### PR TITLE
Move the windows generation out to the outer loop so it's consistent

### DIFF
--- a/R/bag_of_patterns_knn.R
+++ b/R/bag_of_patterns_knn.R
@@ -37,10 +37,23 @@ bagofpatterns_knn <- function(data,
       sparse_windows_val = ifelse(sparse_windows, floor(sqrt(ncol(FaceAll_TRAIN))), NA_real_),
       alphabet_size = alphabet_size,
       PAA_number = PAA_number,
-      breakpoints = breakpoints
+      breakpoints = breakpoints,
+      windows = NA
     )
   )
   X_df <- data[,!colnames(data) == target]
+
+  vec_length <- ncol(X_df)
+    windows <- data.frame(
+      window_starts = 1:(vec_length - window_size + 1),
+      window_ends = window_size:vec_length
+    )
+
+  if(sparse_windows) {
+    windows <- dplyr::slice_sample(windows, n = model_data$SAX_args$sparse_windows_val)
+  }
+
+  model_data$SAX_args$windows <- windows
 
   converted_training_data = convert_df_to_bag_of_words(X_df,
                                                        window_size = model_data$SAX_args$window_size,
@@ -48,7 +61,8 @@ bagofpatterns_knn <- function(data,
                                                        alphabet_size = model_data$SAX_args$alphabet_size,
                                                        PAA_number = model_data$SAX_args$PAA_number,
                                                        breakpoints = model_data$SAX_args$breakpoints,
-                                                       verbose = verbose)
+                                                       verbose = verbose,
+                                                       windows = model_data$SAX_args$windows)
   converted_training_data[target] <- data[target]
   model_data$converted_training_data <- converted_training_data
 

--- a/R/internal_functions.R
+++ b/R/internal_functions.R
@@ -1,17 +1,13 @@
 
 #' @importFrom seewave SAX
 #' @importFrom dplyr slice_sample
-convert_vector_to_word_hist <- function(vec, window_size, sparse_windows_val, alphabet_size, PAA_number, breakpoints) {
-  vec_length <- length(vec)
-
-  windows <- data.frame(
-    window_starts = 1:(vec_length - window_size + 1),
-    window_ends = window_size:vec_length
-  )
-
-  if(!is.na(sparse_windows_val)) {
-    windows <- dplyr::slice_sample(windows, n = sparse_windows_val)
-  }
+convert_vector_to_word_hist <- function(vec,
+                                        window_size,
+                                        sparse_windows_val,
+                                        alphabet_size,
+                                        PAA_number,
+                                        breakpoints,
+                                        windows) {
 
   words <- character(nrow(windows))
   idx <- 1
@@ -44,7 +40,15 @@ convert_vector_to_word_hist <- function(vec, window_size, sparse_windows_val, al
 #' @importFrom tibble as_tibble
 #' @importFrom data.table rbindlist dcast
 #' @importFrom tidyr pivot_wider
-convert_df_to_bag_of_words <- function(data, window_size, sparse_windows_val, alphabet_size, PAA_number, breakpoints, verbose) {
+convert_df_to_bag_of_words <- function(data,
+                                       window_size,
+                                       sparse_windows_val,
+                                       alphabet_size,
+                                       PAA_number,
+                                       breakpoints,
+                                       verbose,
+                                       windows) {
+
   bow <- purrr::map(1:nrow(data), ~ {
     if (verbose) print(.x)
     convert_vector_to_word_hist(unlist(data[.x,]),
@@ -52,7 +56,8 @@ convert_df_to_bag_of_words <- function(data, window_size, sparse_windows_val, al
                                 sparse_windows_val = sparse_windows_val,
                                 alphabet_size = alphabet_size,
                                 PAA_number = PAA_number,
-                                breakpoints = breakpoints)
+                                breakpoints = breakpoints,
+                                windows = windows)
   }, .id = "idx"
   ) %>% data.table::rbindlist(idcol = TRUE)
 

--- a/R/predict_bagofpatterns_knn.R
+++ b/R/predict_bagofpatterns_knn.R
@@ -26,7 +26,8 @@ predict_bagofpatterns_knn <- function(model, newdata = NULL, verbose = TRUE) {
                                                       alphabet_size = model$SAX_args$alphabet_size,
                                                       PAA_number = model$SAX_args$PAA_number,
                                                       breakpoints = model$SAX_args$breakpoints,
-                                                      verbose = verbose)
+                                                      verbose = verbose,
+                                                      windows = model$SAX_args$windows)
 
     converted_test_data_training_only <- converted_test_data[,which(colnames(converted_test_data) %in% colnames(model$converted_training_data))]
 


### PR DESCRIPTION
The windows were being generated at each row, which was inefficient, but also meant that the `sparse_windows` call wasn't very consistent or predictable in the way it worked. Now the test set will use the same window intervals the training set does as well.