### PR TITLE
Add normalizing by the total vector mean and sd

### DIFF
--- a/R/bag_of_patterns_knn.R
+++ b/R/bag_of_patterns_knn.R
@@ -11,6 +11,8 @@
 #' @param target the name of the column where the class of each row is stored
 #' @param k number of neighbours to base the predicted class on
 #' @param window_size The size of the sliding windows as applied to the time series
+#' @param sparse_windows a logical, indicating whether `sqrt(m)` random windows should be taken instead of all
+#' @param normalize a logical, indicating whether each window should be z-normalized (`(x - mean(x)/sd(x)`)
 #' @param alphabet_size the number of distinct letters to use in the compressed SAX representation
 #' @param PAA_number the size of the 'words' generated out of the alphabet by SAX
 #' @param breakpoints the method used to assign letters (see `seewave::SAX`)
@@ -23,6 +25,7 @@ bagofpatterns_knn <- function(data,
                               k = 1,
                               window_size = 200,
                               sparse_windows = FALSE,
+                              normalize = TRUE,
                               alphabet_size = 4,
                               PAA_number = 8,
                               breakpoints = "quantiles",
@@ -36,6 +39,7 @@ bagofpatterns_knn <- function(data,
     SAX_args = list(
       window_size = window_size,
       sparse_windows_val = ifelse(sparse_windows, floor(sqrt(ncol(FaceAll_TRAIN))), NA_real_),
+      normalize = normalize,
       alphabet_size = alphabet_size,
       PAA_number = PAA_number,
       breakpoints = breakpoints,
@@ -60,6 +64,7 @@ bagofpatterns_knn <- function(data,
   converted_training_data = convert_df_to_bag_of_words(X_df,
                                                        window_size = model_data$SAX_args$window_size,
                                                        sparse_windows_val = model_data$SAX_args$sparse_windows_val,
+                                                       normalize = model_data$SAX_args$normalize,
                                                        alphabet_size = model_data$SAX_args$alphabet_size,
                                                        PAA_number = model_data$SAX_args$PAA_number,
                                                        breakpoints = model_data$SAX_args$breakpoints,

--- a/R/internal_functions.R
+++ b/R/internal_functions.R
@@ -4,6 +4,7 @@
 convert_vector_to_word_hist <- function(vec,
                                         window_size,
                                         sparse_windows_val,
+                                        normalize,
                                         alphabet_size,
                                         PAA_number,
                                         breakpoints,
@@ -11,6 +12,9 @@ convert_vector_to_word_hist <- function(vec,
 
   words <- character(nrow(windows))
   idx <- 1
+  if (normalize) {
+    vec <- (vec - mean(vec))/sd(vec)
+  }
 
   for (k2 in 1:nrow(windows)) {
     start <- (windows$window_starts[k2])
@@ -43,6 +47,7 @@ convert_vector_to_word_hist <- function(vec,
 convert_df_to_bag_of_words <- function(data,
                                        window_size,
                                        sparse_windows_val,
+                                       normalize,
                                        alphabet_size,
                                        PAA_number,
                                        breakpoints,
@@ -54,6 +59,7 @@ convert_df_to_bag_of_words <- function(data,
     convert_vector_to_word_hist(unlist(data[.x,]),
                                 window_size = window_size,
                                 sparse_windows_val = sparse_windows_val,
+                                normalize = normalize,
                                 alphabet_size = alphabet_size,
                                 PAA_number = PAA_number,
                                 breakpoints = breakpoints,

--- a/R/methods.R
+++ b/R/methods.R
@@ -15,6 +15,7 @@ print.bagofpatterns <- function(x) {
   cat("  Word Size:", x$SAX_args$PAA_number, "\n")
   cat("  SAX breakpoint method:", x$SAX_args$breakpoints, "\n")
   cat("  Trained with sparse windows:", sparse_windows, "\n")
+  cat("  Windows Z-normalized before creating words:", x$SAX_args$normalize, "\n")
   cat("\n")
   cat("Examples of words in dictionary include:", paste(first_x_words, collapse = ", "))
 

--- a/R/predict_bagofpatterns_knn.R
+++ b/R/predict_bagofpatterns_knn.R
@@ -23,6 +23,7 @@ predict.bagofpatterns <- function(model, newdata = NULL, verbose = TRUE) {
     converted_test_data <- convert_df_to_bag_of_words(X_test_df,
                                                       window_size = model$SAX_args$window_size,
                                                       sparse_windows_val = model$SAX_args$sparse_windows_val,
+                                                      normalize = model$SAX_args$normalize,
                                                       alphabet_size = model$SAX_args$alphabet_size,
                                                       PAA_number = model$SAX_args$PAA_number,
                                                       breakpoints = model$SAX_args$breakpoints,

--- a/README.Rmd
+++ b/README.Rmd
@@ -41,7 +41,8 @@ data("FaceAll_TEST")
 model <- bagofpatternsr::bagofpatterns_knn(FaceAll_TRAIN, 
                                            target = "target",
                                            window_size = floor(sqrt(ncol(FaceAll_TRAIN))),
-                                           verbose = FALSE, 
+                                           verbose = FALSE,
+                                           normalize = TRUE,
                                            alphabet_size = 2, 
                                            PAA_number = 3)
 print(model)
@@ -66,7 +67,8 @@ data("FreezerRegularTrain_TRAIN")
 
 model <- bagofpatterns_knn(FreezerRegularTrain_TRAIN, 
                            window_size = 100, 
-                           sparse_windows = FALSE, 
+                           sparse_windows = FALSE,
+                           normalize = TRUE,
                            k = 1, 
                            verbose = FALSE, 
                            alphabet_size = 2,

--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ data("FaceAll_TEST")
 model <- bagofpatternsr::bagofpatterns_knn(FaceAll_TRAIN, 
                                            target = "target",
                                            window_size = floor(sqrt(ncol(FaceAll_TRAIN))),
-                                           verbose = FALSE, 
+                                           verbose = FALSE,
+                                           normalize = TRUE,
                                            alphabet_size = 2, 
                                            PAA_number = 3)
 print(model)
@@ -51,6 +52,7 @@ print(model)
 #>   Word Size: 3 
 #>   SAX breakpoint method: quantiles 
 #>   Trained with sparse windows: FALSE 
+#>   Windows Z-normalized before creating words: TRUE 
 #> 
 #> Examples of words in dictionary include: aaa, aab, aba, abb, baa
 ```
@@ -64,22 +66,22 @@ new_preds  <- predict(model,
 table(new_preds, FaceAll_TEST$target)
 #>          
 #> new_preds  1 10 11 12 13 14  2  3  4  5  6  7  8  9
-#>        1  30 12  0  4  3  4 16  2 13  4  7 11 10 16
-#>        10  3 26  2  4 34  2  6 11  4  5  4  8 30 16
-#>        11  4  3  0  4 25  0  8 13  5 20 14  5 18  5
-#>        12  0  0  1 13 46  0  9 21  7 10  4  9 23  7
-#>        13  2  7  3  4 22  0  3  6  5 14  9  4 15  3
-#>        14  1  6  0  2 10  1  7  0 10  8 16  5 13  8
-#>        2   7  3  0  3  5  3 18  2  9  8 14 14 16  6
-#>        3   1  8  0  4 70  0  0 51  3 13  3  2 19  2
-#>        4   4  3  0  2  3  1 14  2 32  6  8  6  5  4
-#>        5   1  1  0  4 16  5  5 11  2 13 11  4 10  1
-#>        6   3  3  0  3 15  9 18  3 14 13 32  3  4  8
-#>        7   2  1  1  5 10  1  5  4 10  7 10 14 11  2
-#>        8   4  9  1  6 19  4 19  6  7  6  9 18 35  7
-#>        9  10 13  0  8  9  2 10  4 10  9  6  6 24 15
+#>        1  27 10  0  4  3  4 14  1 14  3  8  8 10 15
+#>        10  4 25  0  5 35  1  4 13  4  6  6  8 31 18
+#>        11  3  1  0  3 24  1 12 11  5 20 16  6 16  3
+#>        12  0  1  1 14 46  1  8 19  7  7  5  8 25  5
+#>        13  4 10  3  2 15  0  3  8  4 15 10  4 17  3
+#>        14  2  6  0  4 10  1  5  0  9  8 13  7 15  7
+#>        2   5  3  0  2  6  2 19  2  9  6 14 11 11  6
+#>        3   1  8  0  5 76  0  1 56  2 15  2  2 22  2
+#>        4   4  3  0  2  4  2 14  2 32  7 10  5  6  3
+#>        5   1  1  0  2 18  5  6  7  2 16 10  4 10  1
+#>        6   2  4  0  3 17  9 19  3 17 13 32  4  4 10
+#>        7   3  0  1  6  6  1  7  5  9  8 10 20  8  3
+#>        8   6 10  3  5 18  3 16  6  6  5  6 16 34  9
+#>        9  10 13  0  9  9  2 10  3 11  7  5  6 24 15
 mean(new_preds == FaceAll_TEST$target)
-#> [1] 0.1786982
+#> [1] 0.1810651
 ```
 
 There’s support for the entirely atheoretical idea of ‘sparse windows’ -
@@ -94,7 +96,8 @@ data("FreezerRegularTrain_TRAIN")
 
 model <- bagofpatterns_knn(FreezerRegularTrain_TRAIN, 
                            window_size = 100, 
-                           sparse_windows = FALSE, 
+                           sparse_windows = FALSE,
+                           normalize = TRUE,
                            k = 1, 
                            verbose = FALSE, 
                            alphabet_size = 2,
@@ -105,10 +108,10 @@ preds <- predict(model, FreezerRegularTrain_TEST, verbose = FALSE)
 table(preds, FreezerRegularTrain_TEST$target)
 #>      
 #> preds    1    2
-#>     1 1057  584
-#>     2  368  841
+#>     1 1053  578
+#>     2  372  847
 mean(preds == FreezerRegularTrain_TEST$target)
-#> [1] 0.6659649
+#> [1] 0.6666667
 ```
 
 With:
@@ -128,8 +131,8 @@ preds <- predict(model, FreezerRegularTrain_TEST, verbose = FALSE)
 table(preds, FreezerRegularTrain_TEST$target)
 #>      
 #> preds   1   2
-#>     1 925 782
-#>     2 500 643
+#>     1 769 669
+#>     2 656 756
 mean(preds == FreezerRegularTrain_TEST$target)
-#> [1] 0.5501754
+#> [1] 0.5350877
 ```

--- a/man/bagofpatterns_knn.Rd
+++ b/man/bagofpatterns_knn.Rd
@@ -10,6 +10,7 @@ bagofpatterns_knn(
   k = 1,
   window_size = 200,
   sparse_windows = FALSE,
+  normalize = TRUE,
   alphabet_size = 4,
   PAA_number = 8,
   breakpoints = "quantiles",


### PR DESCRIPTION
As suggested here:

[Bag-Of-SFA-Symbols in Vector Space (BOSS VS) (Schafer, 2015)](https://www.semanticscholar.org/paper/Bag-Of-SFA-Symbols-in-Vector-Space-(BOSS-VS)-Sch%C3%A4fer/5adfdf0b4e7310e8065e5e6dde2decf4dcc2319e)

Add a default option to normalize each vector by its total mean and sd before creating the word. They actually suggest normalizing by _all of the vectors_ which seems a bit crazy to me, but we may come back to that.