### PR TITLE
Moves Sparsity (and bake_ fix)

### DIFF
--- a/R/bake_bagofpatterns.R
+++ b/R/bake_bagofpatterns.R
@@ -16,6 +16,11 @@ bake_bagofpatterns <- function(bagofpatterns_obj, newdata = NULL) {
     X_test_df <- newdata[,!colnames(newdata) == bagofpatterns_obj$target]
     convert_call_args <- append(list(data = X_test_df), bagofpatterns_obj$SAX_args)
     converted_test_data <- do.call(convert_df_to_bag_of_words, convert_call_args)
+
+    converted_test_data <- as.matrix(converted_test_data)
+    converted_test_data <- tibble::as_tibble(converted_test_data)
+    converted_test_data[bagofpatterns_obj$target] <- newdata[bagofpatterns_obj$target]
+
     converted_test_data_training_only <- converted_test_data[,which(colnames(converted_test_data) %in% colnames(bagofpatterns_obj$converted_training_data))]
     missing_colnames <- colnames(bagofpatterns_obj$converted_training_data)[which(!colnames(bagofpatterns_obj$converted_training_data) %in% colnames(converted_test_data_training_only))]
     converted_test_data_training_only[missing_colnames] <- 0

--- a/R/fit_bagofpatterns.R
+++ b/R/fit_bagofpatterns.R
@@ -68,6 +68,15 @@ fit_bagofpatterns <- function(data,
 
   convert_call_args <- append(list(data = X_df), bagofpatterns_obj$SAX_args)
   converted_training_data <- do.call(convert_df_to_bag_of_words, convert_call_args)
+
+  if (!is.na(maximum_sparsity)) {
+    converted_training_data_sparse <- tm::removeSparseTerms(converted_training_data, sparse = maximum_sparsity)
+    if (tm::nTerms(converted_training_data_sparse) < 2) stop("Sparsity constraint resulted in less than two words used. Try a value closer to 1.")
+    converted_training_data <- converted_training_data_sparse
+  }
+  converted_training_data <- as.matrix(converted_training_data)
+  converted_training_data <- tibble::as_tibble(converted_training_data)
+
   converted_training_data[target] <- data[target]
   bagofpatterns_obj$converted_training_data <- converted_training_data
 

--- a/R/internal_functions.R
+++ b/R/internal_functions.R
@@ -73,14 +73,6 @@ convert_df_to_bag_of_words <- function(data,
   ) %>% data.table::rbindlist(idcol = TRUE)
 
   bow <- bow[, list(Freq = sum(Freq)), keyby = list(.id,words)]
-
   bow_dtm <- tidytext::cast_dtm(bow, .id, words, Freq, weighting = word_weighting)
-  if (!is.na(maximum_sparsity)) {
-    bow_dtm_sparse <- tm::removeSparseTerms(bow_dtm, sparse = maximum_sparsity)
-    if (tm::nTerms(bow_dtm_sparse) < 2) stop("Sparsity constraint resulted in less than two words used. Try a value closer to 1.")
-    bow_dtm <- bow_dtm_sparse
-  }
-  bow <- as.matrix(bow_dtm)
-  bow <- tibble::as_tibble(bow)
-    return(bow)
+  return(bow_dtm)
 }


### PR DESCRIPTION
Moving sparsity out into the fit method means it gets passed once, the right way. Also a small fix for the bake method - not sure how it even worked before since it never re-added the target column. Closes #13 