### PR TITLE
Fix Bag-of-Patterns word counting

### DIFF
--- a/R/internal_functions.R
+++ b/R/internal_functions.R
@@ -29,8 +29,13 @@ convert_vector_to_word_hist <- function(vec,
                 collapse = "")
   })
   
-  # Convert to vector and remove duplicates in one step
-  words <- unique(unlist(words))
+  # Convert list of words to vector
+  #
+  # Duplicates must be preserved so that the frequency table
+  # correctly reflects how often each word occurs in the sliding
+  # windows.  Using `unique()` here would discard repeated words and
+  # therefore return incorrect counts.
+  words <- unlist(words)
   
   # Create frequency table directly with data.table
   word_counts <- data.table::as.data.table(table(words))

--- a/R/methods.R
+++ b/R/methods.R
@@ -69,7 +69,11 @@ print.bagofpatterns <- function(x, ...) {
 
     # Print remaining parameters safely
     cat("  Alphabet Size:", x$SAX_args$alphabet_size, "\n")
-    cat("  Word Size:", x$SAX_args$PAA_number, "\n")
+    # Stored parameter name is 'word_size', but earlier versions
+    # mistakenly attempted to access 'PAA_number'.  Use the
+    # correct element so the printed summary reflects the model
+    # settings.
+    cat("  Word Size:", x$SAX_args$word_size, "\n")
     cat("  SAX breakpoint method:", x$SAX_args$breakpoints, "\n")
 
     # Only show weighting method if available


### PR DESCRIPTION
## Summary
- fix counting of repeated words in histogram generation
- correct word size display in `print.bagofpatterns`

## Testing
- `devtools::test()` *(fails: `R` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fe6dc54d0832491f6d0e80ea43ec0