### PR TITLE
Remove verbose param from docs

### DIFF
--- a/R/predict_bagofpatterns_knn.R
+++ b/R/predict_bagofpatterns_knn.R
@@ -9,7 +9,6 @@
 #'
 #' @param model a fitted model returned by `bagofpatterns_knn`
 #' @param newdata optional new data frame - if not passed, will return training set predictions
-#' @param verbose whether to print the fitting steps when creating the BoP representation
 #' @param ... Not used, left for generics consistency.
 #' @examples
 #' data("FaceAll_TRAIN")

--- a/man/predict.bagofpatterns.Rd
+++ b/man/predict.bagofpatterns.Rd
@@ -13,8 +13,6 @@
 
 \item{...}{Not used, left for generics consistency.}
 
-\item{verbose}{whether to print the fitting steps when creating the BoP representation}
-}
 \description{
 Classifies new time series according to a trained BoP model using KNN
 }
@@ -27,6 +25,4 @@ the words present in the training data as the basis for neighbour matching.
 \examples{
 data("FaceAll_TRAIN")
 data("FaceAll_TEST")
-model <- bagofpatterns_knn(FaceAll_TRAIN, window_size = 10, verbose = FALSE, k = 1)
-new_preds  <- predict(model, newdata = FaceAll_TEST, verbose = FALSE)
 }


### PR DESCRIPTION
## Summary
- drop undocumented `verbose` parameter from `predict_bagofpatterns_knn.R`
- update `predict.bagofpatterns` Rd file

## Testing
- `Rscript -e "devtools::document();"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fe8b6063c83248cb7f8ee9310bf69