### PR TITLE
Fix grammar in README

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -60,7 +60,7 @@ mean(new_preds == FaceAll_TEST$target)
 
 ```
 
-There's support for the entirely atheoretical idea of 'sparse windows' - essentially, rather than generating a dictionary out of every single window, we take inspiration from Time Series Forest by taking `sqrt(m)` random windows from each vector. It speed up training dramatically, and seems to improve generalization - compare:
+There's support for the entirely atheoretical idea of 'sparse windows' - essentially, rather than generating a dictionary out of every single window, we take inspiration from Time Series Forest by taking `sqrt(m)` random windows from each vector. It **speeds** up training dramatically, and seems to improve generalization - compare:
 
 ```{r train_2_nosparse}
 library(tsforest)

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ mean(as.character(new_preds) == as.character(FaceAll_TEST$target))
 There’s support for the entirely atheoretical idea of ‘sparse windows’ -
 essentially, rather than generating a dictionary out of every single
 window, we take inspiration from Time Series Forest by taking `sqrt(m)`
-random windows from each vector. It speed up training dramatically, and
+random windows from each vector. It **speeds** up training dramatically, and
 seems to improve generalization - compare:
 
 ``` r


### PR DESCRIPTION
## Summary
- update README references to 'speeds up'
- keep README and README.Rmd consistent

## Testing
- `R -q -e "rmarkdown::render('README.Rmd')"` *(fails: command not found)*
- `Rscript -e "rmarkdown::render('README.Rmd', quiet=TRUE)"` *(fails: command not found)*
- `R CMD build .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fe8ba30c48324ba6b55ddd1e2a5a3