### PR TITLE
Fix word size print

### DIFF
--- a/R/methods.R
+++ b/R/methods.R
@@ -69,7 +69,7 @@ print.bagofpatterns <- function(x, ...) {
 
     # Print remaining parameters safely
     cat("  Alphabet Size:", x$SAX_args$alphabet_size, "\n")
-    cat("  Word Size:", x$SAX_args$PAA_number, "\n")
+    cat("  Word Size:", x$SAX_args$word_size, "\n")
     cat("  SAX breakpoint method:", x$SAX_args$breakpoints, "\n")
 
     # Only show weighting method if available


### PR DESCRIPTION
## Summary
- show the correct word size argument in `print.bagofpatterns`

## Testing
- `R CMD check .` *(fails: R command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fe864dd588324912534e2c9ac3975